### PR TITLE
sparkbench: avoid to verify file format in SparkFuncs.scala

### DIFF
--- a/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
+++ b/utils/src/main/scala/com/ibm/sparktc/sparkbench/utils/SparkFuncs.scala
@@ -32,7 +32,6 @@ object SparkFuncs {
 
   def verifyOutput(outputDir: Option[String], saveMode: String, spark: SparkSession, fileFormat: Option[String] = None): Unit = {
     verifyCanWriteOrThrow(outputDir, saveMode, spark, fileFormat)
-    verifyFormatOrThrow(outputDir, fileFormat)
   }
   
   def verifyCanWrite(outputDir: String, saveMode: String, spark: SparkSession, fileFormat: Option[String] = None): Boolean = {


### PR DESCRIPTION
commit 992a278f0e2fea6a4333bfe1d7ed98aa95011e0d
Author: Emily Curtin <emily@framebit.org>
Date:   Fri Feb 2 14:46:33 2018 -0500

    Addressing code review comments

    Moves format check to front.

This commit add verifyFormatOrThrow(outputDir, fileFormat) in
verifyOutput(). It causes graph data generator workload failure
since the workload only generate output with txt file format.
But sparkbench only supports csv, parquet, etc. The confliction
of file format causes the workload failure. Now remove the
verifyFormatOrThrow() instead.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>