### PR TITLE
doc: fix invalid workload of data generation lr

### DIFF
--- a/docs/_workloads/data-generator-linear-regression.md
+++ b/docs/_workloads/data-generator-linear-regression.md
@@ -20,15 +20,6 @@ title: Data Generator - Linear Regression
 ```hocon
 {
   name = "data-generation-lr"
-  rows = 100000100
-  cols = 24
-  output = "/tmp/kmeans-data.csv"
-}
-```
-
-```hocon
-{
-  name = "data-generation-lr"
   rows = 100000000
   cols = 24
   output = "/tmp/kmeans-data.parquet"


### PR DESCRIPTION
This workload will output to /tmp/kmeans-data.csv.

In LinearRegressionDataGen.scala, case class LinearRegressionDataGen()
checks whether the output file is csv file or not. If it's csv file,
stop running the workload immediately. So this workload is impossible
to run, just remove it from document.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>