### PR TITLE
doc: remove duplicated workload from kmeans

### DIFF
--- a/docs/_workloads/kmeans.md
+++ b/docs/_workloads/kmeans.md
@@ -36,11 +36,3 @@ will be passed upwards and outputted with the workload suite.
     k = 10
   }
 ```
-
-```hocon
-  {
-    name = "kmeans"
-    input = "/tmp/kmeans-data.parquet"
-    k = 10
-  }
-```


### PR DESCRIPTION
In kmeans document, the same workload is listed twice. Now remove
the duplicated one.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>